### PR TITLE
Windows workarounds

### DIFF
--- a/src/clj/native_image.clj
+++ b/src/clj/native_image.clj
@@ -17,7 +17,10 @@
 
 (defn merged-deps []
   "Merges install, user, local deps.edn maps left-to-right."
-  (-> (deps.reader/clojure-env)
+  (-> (try
+        ;; workaround for TDEPS-128
+        (deps.reader/clojure-env)
+        (catch Throwable _ {:config-files []}))
       (:config-files)
       (concat ["deps.edn"])
       (deps.reader/read-deps)))


### PR DESCRIPTION
With these workarounds I got to the point where GraalVM complains about certain GCC tools not being around.
I haven't been able to fix this, since GraalVM assumes you execute your commands in a special Windows 7.1 SDK shell and clojure kind of assumes Powershell.
But except from that, I worked around some other issues I came across (see #6, #7 and #8)