### PR TITLE
Replace use of clojure-env with new api call

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,4 +1,4 @@
 {:paths ["src"]
  :deps {org.clojure/clojure {:mvn/version "1.10.0"}
-        org.clojure/tools.deps.alpha {:mvn/version "0.6.496"}
+        org.clojure/tools.deps.alpha {:mvn/version "0.7.516"}
         org.clojure/tools.namespace {:mvn/version "0.2.11"}}}

--- a/src/clj/native_image.clj
+++ b/src/clj/native_image.clj
@@ -19,11 +19,7 @@
 
 (defn merged-deps []
   "Merges install, user, local deps.edn maps left-to-right."
-  (-> (if windows?
-        [] ;; workaround TDEPS-128
-        (:config-files (deps.reader/clojure-env)))
-      (concat ["deps.edn"])
-      (deps.reader/read-deps)))
+  (deps.reader/read-deps (deps.reader/default-deps)))
 
 (defn sh
   "Launches a process with optional args, returning exit code.


### PR DESCRIPTION
clojure-env has been deprecated and will be removed. The latest version of tools.deps.alpha has a new method `reader/default-deps`  that can return the set of deps.edn config files that replicates the logic from clj without shelling out.