### PR TITLE
Don't rely on tools.deps' shlexing behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Assuming a project structure like this:
 In your `deps.edn` specify an alias with a dependency on `clj.native-image`:
 ```clojure
 {:aliases {:native-image
-           {:main-opts ["-m clj.native-image core"
+           {:main-opts ["-m" "clj.native-image" "core"
                         "--initialize-at-build-time"
                         ;; optional native image name override
                         "-H:Name=core"]


### PR DESCRIPTION
I'm not sure when this broke, but one of our projects stopped working until I changed this. The error is something like:

```
lvh@cannon ~/s/L/wernicke $ clj -M:native-image       
Execution error (FileNotFoundException) at java.io.FileInputStream/open0 (FileInputStream.java:-2).
-m clj.native-image latacora.wernicke.cli (No such file or directory)

Full report at:
/tmp/clojure-8943822669481933153.edn
```